### PR TITLE
Add system tray minimize flow for desktop client

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Clone  the repository and run the following commands to run the application:
 npm install
 npm run start
 ```
+
+To start the application minimized in the system tray, append one of the following flags after `npm start`:
+
+```bash
+npm start -- --start-in-tray
+# aliases: --tray, --hidden, --start-minimized, --minimized
+```
 ### Build
 Clone  the repository and run the following commands to run the application:
 ```bash

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // Modules to control application life and create native browser window
-const { app, BrowserWindow, shell, nativeImage } = require( 'electron' );
+const { app, BrowserWindow, shell, nativeImage, Tray, Menu } = require( 'electron' );
 const path = require( 'node:path' );
 const contextMenu = require( 'electron-context-menu' );
 const appIcon = nativeImage.createFromPath( path.join( __dirname, 'build/icon.png' ) );
@@ -7,6 +7,8 @@ const appIcon = nativeImage.createFromPath( path.join( __dirname, 'build/icon.pn
 app.disableHardwareAcceleration();
 
 let mainWindow;
+let tray;
+let isQuitting = false;
 
 const createWindow = () => {
 	// Create the browser window.
@@ -41,10 +43,86 @@ const createWindow = () => {
 		sendNotification();
 	} );
 
+	mainWindow.on( 'minimize', event => {
+		event.preventDefault();
+		mainWindow.hide();
+	} );
+
+	mainWindow.on( 'close', event => {
+		if ( isQuitting ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		if ( process.platform === 'darwin' ) {
+			app.hide();
+		} else {
+			mainWindow.hide();
+		}
+	} );
+
 	if ( process.platform === 'darwin' ) {
 		setupDockIcon();
 	}
 };
+
+function setupTray () {
+	if ( tray ) {
+		return;
+	}
+
+	tray = new Tray( appIcon );
+	tray.setToolTip( 'WhatsApp Desktop' );
+
+	const trayMenu = Menu.buildFromTemplate( [
+		{
+			label: 'Mostrar',
+			click: () => {
+				showMainWindow();
+			}
+		},
+		{
+			label: 'Minimizar',
+			click: () => {
+				if ( mainWindow?.isVisible() ) {
+					mainWindow.hide();
+				}
+			}
+		},
+		{ type: 'separator' },
+		{
+			label: 'Sair',
+			click: () => {
+				isQuitting = true;
+				app.quit();
+			}
+		}
+	] );
+
+	tray.setContextMenu( trayMenu );
+
+	tray.on( 'click', () => {
+		showMainWindow();
+	} );
+}
+
+function showMainWindow () {
+	if ( !mainWindow ) {
+		createWindow();
+		return;
+	}
+
+	if ( !mainWindow.isVisible() ) {
+		mainWindow.show();
+	}
+
+	if ( mainWindow.isMinimized() ) {
+		mainWindow.restore();
+	}
+
+	mainWindow.focus();
+}
 
 function setupExternalLinkHandling () {
 	// Open external links in the default browser
@@ -132,6 +210,7 @@ app.whenReady().then( () => {
 	} );
 
 	createWindow();
+	setupTray();
 
 	// On OS X it's common to re-create a window in the app when the
 	// dock icon is clicked and there are no other windows open.
@@ -148,6 +227,15 @@ app.whenReady().then( () => {
 app.on( 'window-all-closed', () => {
 	if ( process.platform !== 'darwin' ) {
 		app.quit();
+	}
+} );
+
+app.on( 'before-quit', () => {
+	isQuitting = true;
+
+	if ( tray ) {
+		tray.destroy();
+		tray = null;
 	}
 } );
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,11 @@ const path = require( 'node:path' );
 const contextMenu = require( 'electron-context-menu' );
 const appIcon = nativeImage.createFromPath( path.join( __dirname, 'build/icon.png' ) );
 
+const cliArgs = process.argv.slice( 1 );
+const shouldStartMinimized = cliArgs.includes( '--start-minimized' ) || cliArgs.includes( '--minimized' );
+const shouldStartInTray = cliArgs.includes( '--start-in-tray' ) || cliArgs.includes( '--tray' ) || cliArgs.includes( '--hidden' );
+const shouldStartHidden = shouldStartMinimized || shouldStartInTray;
+
 app.disableHardwareAcceleration();
 
 let mainWindow;
@@ -17,6 +22,7 @@ const createWindow = () => {
 		height: 800,
 		autoHideMenuBar: true,
 		frame: true,
+		show: false,
 		webPreferences: {
 			nodeIntegration: true,
 			webviewTag: true,
@@ -41,6 +47,14 @@ const createWindow = () => {
 		checkNotificationPermission();
 		setupExternalLinkHandling();
 		sendNotification();
+	} );
+
+	mainWindow.once( 'ready-to-show', () => {
+		if ( shouldStartHidden ) {
+			mainWindow.hide();
+		} else {
+			mainWindow.show();
+		}
 	} );
 
 	mainWindow.on( 'minimize', event => {
@@ -77,13 +91,13 @@ function setupTray () {
 
 	const trayMenu = Menu.buildFromTemplate( [
 		{
-			label: 'Mostrar',
+			label: 'Show',
 			click: () => {
 				showMainWindow();
 			}
 		},
 		{
-			label: 'Minimizar',
+			label: 'Hide to Tray',
 			click: () => {
 				if ( mainWindow?.isVisible() ) {
 					mainWindow.hide();
@@ -92,7 +106,7 @@ function setupTray () {
 		},
 		{ type: 'separator' },
 		{
-			label: 'Sair',
+			label: 'Exit',
 			click: () => {
 				isQuitting = true;
 				app.quit();
@@ -108,7 +122,7 @@ function setupTray () {
 }
 
 function showMainWindow () {
-	if ( !mainWindow ) {
+	if ( !mainWindow || mainWindow.isDestroyed() ) {
 		createWindow();
 		return;
 	}


### PR DESCRIPTION
## Summary
- Create a persistent tray icon with tooltip, quick actions, and single-click restore
- Intercept minimize/close events to hide the window and keep the session active
- Dispose tray resources cleanly on application quit to prevent orphan icons

## Testing
- npm install
- npm start
- Manual: minimize, restore via tray icon, use tray menu Show/Minimize/Exit